### PR TITLE
build(rust): use released `sgx` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,8 @@ dependencies = [
 [[package]]
 name = "sgx"
 version = "0.5.0"
-source = "git+https://github.com/enarx/sgx#dce07198d67ac9287ea00eaf0b407a6fa9ca308c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536c96a764daacb2abe1e22834d5f48c9e285e7cf3683fb40e9d426ea0907437"
 dependencies = [
  "bitflags",
  "x86_64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = "^0.10.2"
 ring = { version = "0.16.20", features = ["std"] }
 zeroize = { version = "^1.5.2", features = ["alloc"] }
 flagset = "0.4.3"
-sgx = { git = "https://github.com/enarx/sgx" }
+sgx = { version = "0.5.0" }
 
 tracing-subscriber = { version="^0.3.8", features = ["env-filter"] }
 axum = { version = "^0.5.1", features = ["headers"] }


### PR DESCRIPTION
In order to make release possible, depend on released version.