### PR TITLE
feat: allow one or more CSRs per request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,12 +307,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -320,6 +336,34 @@ name = "futures-core"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -334,15 +378,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -794,6 +850,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +922,12 @@ dependencies = [
  "pkcs8",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -972,6 +1068,7 @@ dependencies = [
  "mime",
  "pkcs8",
  "ring",
+ "rstest",
  "rustls-pemfile",
  "sec1",
  "sgx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tower = { version = "^0.4.11", features = ["util"] }
 axum = "^0.5.1"
 http = "^0.2.6"
 memoffset = "0.6.4"
+rstest = "0.15"
 testaso = "0.1"
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
 use axum::body::Bytes;
-use axum::extract::Extension;
+use axum::extract::{Extension, TypedHeader};
+use axum::headers::ContentType;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
@@ -52,6 +53,9 @@ use x509::request::{CertReq, ExtensionReq};
 use x509::time::{Time, Validity};
 use x509::{Certificate, TbsCertificate};
 use zeroize::Zeroizing;
+
+const PKCS10: &str = "application/pkcs10";
+const BUNDLE: &str = "application/vnd.steward.pkcs10-bundle.v1";
 
 /// Attestation server for use with Enarx.
 ///
@@ -377,6 +381,7 @@ fn attest_request(
 /// Returns:
 /// ASN.1 SEQUENCE OF Output.
 async fn attest(
+    TypedHeader(ct): TypedHeader<ContentType>,
     body: Bytes,
     Extension(state): Extension<Arc<State>>,
 ) -> Result<Vec<u8>, impl IntoResponse> {
@@ -392,10 +397,15 @@ async fn attest(
         not_after: Time::try_from(end).or(Err(StatusCode::INTERNAL_SERVER_ERROR))?,
     };
 
+    // Check for correct mime type.
+    let reqs = match ct.to_string().as_ref() {
+        PKCS10 => vec![CertReq::from_der(body.as_ref()).or(Err(StatusCode::BAD_REQUEST))?],
+        BUNDLE => Vec::from_der(body.as_ref()).or(Err(StatusCode::BAD_REQUEST))?,
+        _ => return Err(StatusCode::BAD_REQUEST),
+    };
+
     // Decode and verify the certification requests.
-    Vec::<CertReq<'_>>::from_der(body.as_ref())
-        .or(Err(StatusCode::BAD_REQUEST))?
-        .into_iter()
+    reqs.into_iter()
         .map(|cr| {
             // Create the basic subject alt name.
             let name = Ia5StringRef::new("foo.bar.hub.profian.com")
@@ -411,15 +421,20 @@ async fn attest(
         })
         .collect::<Result<Vec<_>, _>>()
         .and_then(|issued| {
-            let issued = issued
+            let issued: Vec<Certificate<'_>> = issued
                 .iter()
                 .map(|c| Certificate::from_der(c).or(Err(StatusCode::INTERNAL_SERVER_ERROR)))
                 .collect::<Result<_, _>>()?;
-            Output {
-                chain: vec![issuer],
-                issued,
+
+            match ct.to_string().as_ref() {
+                PKCS10 => vec![issuer, issued[0].clone()].to_vec(),
+                BUNDLE => Output {
+                    chain: vec![issuer],
+                    issued,
+                }
+                .to_vec(),
+                _ => return Err(StatusCode::BAD_REQUEST),
             }
-            .to_vec()
             .or(Err(StatusCode::INTERNAL_SERVER_ERROR))
         })
 }
@@ -438,8 +453,10 @@ mod tests {
         use x509::{ext::Extension, name::RdnSequence};
 
         use axum::response::Response;
+        use http::header::CONTENT_TYPE;
         use http::Request;
         use hyper::Body;
+        use rstest::rstest;
         use tower::ServiceExt; // for `app.oneshot()`
 
         fn certificates_state() -> State {
@@ -450,7 +467,7 @@ mod tests {
             State::generate(None, "localhost").unwrap()
         }
 
-        fn cr(curve: ObjectIdentifier, exts: Vec<Extension<'_>>) -> Vec<u8> {
+        fn cr(curve: ObjectIdentifier, exts: Vec<Extension<'_>>, multi: bool) -> Vec<u8> {
             let pki = PrivateKeyInfo::generate(curve).unwrap();
             let pki = PrivateKeyInfo::from_der(pki.as_ref()).unwrap();
             let spki = pki.public_key().unwrap();
@@ -471,18 +488,26 @@ mod tests {
             };
 
             // Sign the request.
-            vec![CertReq::from_der(&cri.sign(&pki).unwrap()).unwrap()]
-                .to_vec()
-                .unwrap()
+            let signed = cri.sign(&pki).unwrap();
+            if multi {
+                vec![CertReq::from_der(&signed).unwrap()].to_vec().unwrap()
+            } else {
+                signed
+            }
         }
 
-        async fn attest_response(state: State, response: Response) {
+        async fn attest_response(state: State, response: Response, multi: bool) {
             let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
 
-            let response = Output::from_der(body.as_ref()).unwrap();
+            let path = if multi {
+                let response = Output::from_der(body.as_ref()).unwrap();
+                let mut path = PkiPath::from(response.chain);
+                path.push(response.issued[0].clone());
+                path
+            } else {
+                PkiPath::from_der(&body).unwrap()
+            };
 
-            let mut path = PkiPath::from(response.chain);
-            path.push(response.issued[0].clone());
             let issr = Certificate::from_der(&state.crt).unwrap();
             assert_eq!(2, path.len());
             assert_eq!(issr, path[0]);
@@ -490,8 +515,8 @@ mod tests {
         }
 
         #[test]
-        fn reencode() {
-            let encoded = cr(SECP_256_R_1, vec![]);
+        fn reencode_multi() {
+            let encoded = cr(SECP_256_R_1, vec![], true);
             let crs = Vec::<CertReq<'_>>::from_der(&encoded).unwrap();
             assert_eq!(crs.len(), 1);
 
@@ -501,8 +526,19 @@ mod tests {
             assert_eq!(encoded, reencoded);
         }
 
+        #[test]
+        fn reencode_single() {
+            let encoded = cr(SECP_256_R_1, vec![], false);
+            let decoded = CertReq::from_der(&encoded).unwrap();
+            let reencoded = decoded.to_vec().unwrap();
+            assert_eq!(encoded, reencoded);
+        }
+
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn kvm_certs() {
+        async fn kvm_certs(#[case] header: &str, #[case] multi: bool) {
             let ext = Extension {
                 extn_id: Kvm::OID,
                 critical: false,
@@ -512,16 +548,20 @@ mod tests {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
-                .body(Body::from(cr(SECP_256_R_1, vec![ext])))
+                .header(CONTENT_TYPE, header)
+                .body(Body::from(cr(SECP_256_R_1, vec![ext], multi)))
                 .unwrap();
 
             let response = app(certificates_state()).oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            attest_response(certificates_state(), response).await;
+            attest_response(certificates_state(), response, multi).await;
         }
 
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn kvm_hostname() {
+        async fn kvm_hostname(#[case] header: &str, #[case] multi: bool) {
             let ext = Extension {
                 extn_id: Kvm::OID,
                 critical: false,
@@ -531,15 +571,18 @@ mod tests {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
-                .body(Body::from(cr(SECP_256_R_1, vec![ext])))
+                .header(CONTENT_TYPE, header)
+                .body(Body::from(cr(SECP_256_R_1, vec![ext], multi)))
                 .unwrap();
 
             let state = hostname_state();
             let response = app(state.clone()).oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            attest_response(state, response).await;
+            attest_response(state, response, multi).await;
         }
 
+        // Though similar to the above test, this is the only test which
+        // actually sends many CSRs, versus an array of just one CSR.
         #[tokio::test]
         async fn kvm_hostname_many_certs() {
             let ext = Extension {
@@ -548,7 +591,7 @@ mod tests {
                 extn_value: &[],
             };
 
-            let one_cr_bytes = cr(SECP_256_R_1, vec![ext]);
+            let one_cr_bytes = cr(SECP_256_R_1, vec![ext], true);
             let crs = Vec::<CertReq<'_>>::from_der(&one_cr_bytes).unwrap();
             assert_eq!(crs.len(), 1);
 
@@ -562,6 +605,7 @@ mod tests {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
+                .header(CONTENT_TYPE, BUNDLE)
                 .body(Body::from(five_crs.to_vec().unwrap()))
                 .unwrap();
 
@@ -575,8 +619,11 @@ mod tests {
             assert_eq!(output.issued.len(), five_crs.len());
         }
 
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn sgx_certs() {
+        async fn sgx_certs(#[case] header: &str, #[case] multi: bool) {
             for quote in [
                 include_bytes!("ext/sgx/quote.unknown").as_slice(),
                 include_bytes!("ext/sgx/quote.icelake").as_slice(),
@@ -590,17 +637,21 @@ mod tests {
                 let request = Request::builder()
                     .method("POST")
                     .uri("/")
-                    .body(Body::from(cr(SECP_256_R_1, vec![ext])))
+                    .header(CONTENT_TYPE, header)
+                    .body(Body::from(cr(SECP_256_R_1, vec![ext], multi)))
                     .unwrap();
 
                 let response = app(certificates_state()).oneshot(request).await.unwrap();
                 assert_eq!(response.status(), StatusCode::OK);
-                attest_response(certificates_state(), response).await;
+                attest_response(certificates_state(), response, multi).await;
             }
         }
 
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn sgx_hostname() {
+        async fn sgx_hostname(#[case] header: &str, #[case] multi: bool) {
             for quote in [
                 include_bytes!("ext/sgx/quote.unknown").as_slice(),
                 include_bytes!("ext/sgx/quote.icelake").as_slice(),
@@ -614,18 +665,22 @@ mod tests {
                 let request = Request::builder()
                     .method("POST")
                     .uri("/")
-                    .body(Body::from(cr(SECP_256_R_1, vec![ext])))
+                    .header(CONTENT_TYPE, header)
+                    .body(Body::from(cr(SECP_256_R_1, vec![ext], multi)))
                     .unwrap();
 
                 let state = hostname_state();
                 let response = app(state.clone()).oneshot(request).await.unwrap();
                 assert_eq!(response.status(), StatusCode::OK);
-                attest_response(state, response).await;
+                attest_response(state, response, multi).await;
             }
         }
 
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn snp_certs() {
+        async fn snp_certs(#[case] header: &str, #[case] multi: bool) {
             let evidence = ext::snp::Evidence {
                 vcek: Certificate::from_der(include_bytes!("ext/snp/milan.vcek")).unwrap(),
                 report: include_bytes!("ext/snp/milan.rprt"),
@@ -642,16 +697,20 @@ mod tests {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
-                .body(Body::from(cr(SECP_384_R_1, vec![ext])))
+                .header(CONTENT_TYPE, header)
+                .body(Body::from(cr(SECP_384_R_1, vec![ext], multi)))
                 .unwrap();
 
             let response = app(certificates_state()).oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            attest_response(certificates_state(), response).await;
+            attest_response(certificates_state(), response, multi).await;
         }
 
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn snp_hostname() {
+        async fn snp_hostname(#[case] header: &str, #[case] multi: bool) {
             let evidence = ext::snp::Evidence {
                 vcek: Certificate::from_der(include_bytes!("ext/snp/milan.vcek")).unwrap(),
                 report: include_bytes!("ext/snp/milan.rprt"),
@@ -668,21 +727,26 @@ mod tests {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
-                .body(Body::from(cr(SECP_384_R_1, vec![ext])))
+                .header(CONTENT_TYPE, header)
+                .body(Body::from(cr(SECP_384_R_1, vec![ext], multi)))
                 .unwrap();
 
             let state = hostname_state();
             let response = app(state.clone()).oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
-            attest_response(state, response).await;
+            attest_response(state, response, multi).await;
         }
 
+        #[rstest]
+        #[case(PKCS10, false)]
+        #[case(BUNDLE, true)]
         #[tokio::test]
-        async fn err_no_attestation_certs() {
+        async fn err_no_attestation_certs(#[case] header: &str, #[case] multi: bool) {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
-                .body(Body::from(cr(SECP_256_R_1, vec![])))
+                .header(CONTENT_TYPE, header)
+                .body(Body::from(cr(SECP_256_R_1, vec![], multi)))
                 .unwrap();
 
             let response = app(certificates_state()).oneshot(request).await.unwrap();
@@ -694,11 +758,27 @@ mod tests {
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
-                .body(Body::from(cr(SECP_256_R_1, vec![])))
+                .header(CONTENT_TYPE, BUNDLE)
+                .body(Body::from(cr(SECP_256_R_1, vec![], true)))
                 .unwrap();
 
             let response = app(hostname_state()).oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        }
+
+        #[rstest]
+        #[case(false)]
+        #[case(true)]
+        #[tokio::test]
+        async fn err_no_content_type(#[case] multi: bool) {
+            let request = Request::builder()
+                .method("POST")
+                .uri("/")
+                .body(Body::from(cr(SECP_256_R_1, vec![], multi)))
+                .unwrap();
+
+            let response = app(certificates_state()).oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         }
 
         #[tokio::test]
@@ -727,13 +807,14 @@ mod tests {
 
         #[tokio::test]
         async fn err_bad_csr_sig() {
-            let mut cr = cr(SECP_256_R_1, vec![]);
+            let mut cr = cr(SECP_256_R_1, vec![], true);
             let last = cr.last_mut().unwrap();
             *last = last.wrapping_add(1); // Modify the signature...
 
             let request = Request::builder()
                 .method("POST")
                 .uri("/")
+                .header(CONTENT_TYPE, BUNDLE)
                 .body(Body::from(cr))
                 .unwrap();
 


### PR DESCRIPTION
Determined by `CONTENT_TYPE`, Steward will accept one CSR and issue one Certificate, or will accept a `Vec<Certficiate>` and return a struct containing separate `Vec<Certificate>`s, one for the issuing chain, and one for the certificates issued.

Signed-off-by: Richard Zak <richard@profian.com>