### PR TITLE
feat: wasm32-wasi support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[build]
+target = "wasm32-wasi"
+rustflags = ["--cfg", "tokio_unstable"]
+runner = ["enarx", "run", "--wasmcfgfile", "Enarx.toml"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,3 @@
-[build]
-target = "wasm32-wasi"
+[target.wasm32-wasi]
 rustflags = ["--cfg", "tokio_unstable"]
 runner = ["enarx", "run", "--wasmcfgfile", "Enarx.toml"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,32 @@
 name: Test
 on: [ push, pull_request ]
 jobs:
-  test:
+  test_native:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
     - name: Setup Rust toolchain
       run: rustup show
-    - name: cargo test
+    - name: cargo test native
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --all-features
+        args: --workspace --all-features --target=x86_64-unknown-linux-musl
+
+  test_wasi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Setup Rust toolchain
+        run: rustup show
+      - name: install wasi
+        run: rustup target install wasm32-wasi
+      - name: download enarx
+        run: curl -sLO https://github.com/enarx/enarx/releases/download/v0.6.4/enarx-0.6.4-1_amd64.deb
+      - name: install enarx
+        run: sudo dpkg -i enarx-0.6.4-1_amd64.deb
+      - name: cargo test wasm32-wasi
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --all-features --target=wasm32-wasi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 name: Test
 on: [ push, pull_request ]
 jobs:
-  test:
+  native:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
     - name: Setup Rust toolchain
       run: rustup show
     - name: cargo test
@@ -13,19 +13,17 @@ jobs:
         command: test
         args: --workspace --all-features
 
-  test_wasi:
+  wasi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - name: Setup Rust toolchain
         run: rustup show
-      - name: install wasi
-        run: rustup target install wasm32-wasi
-      - name: download enarx
+      - name: Download enarx
         run: curl -sLO https://github.com/enarx/enarx/releases/download/v0.6.4/enarx-0.6.4-1_amd64.deb
-      - name: install enarx
+      - name: Install enarx
         run: sudo dpkg -i enarx-0.6.4-1_amd64.deb
-      - name: cargo test wasm32-wasi
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,17 @@
 name: Test
 on: [ push, pull_request ]
 jobs:
-  test_native:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
     - name: Setup Rust toolchain
       run: rustup show
-    - name: cargo test native
+    - name: cargo test
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --all-features --target=x86_64-unknown-linux-musl
+        args: --workspace --all-features
 
   test_wasi:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,25 +487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,14 +593,12 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 [[package]]
 name = "hyper"
 version = "0.14.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+source = "git+https://github.com/rjzak/hyper?branch=wasi_wip#cbb93bd1c9707686fb64205a680246a11324982d"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -669,16 +648,6 @@ name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
-
-[[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -827,29 +796,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
 ]
 
 [[package]]
@@ -1010,15 +956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,12 +1067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,15 +1155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1411,14 +1333,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
- "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -1433,20 +1351,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 [[package]]
 name = "hyper"
 version = "0.14.20"
-source = "git+https://github.com/rjzak/hyper?branch=wasi_wip#cbb93bd1c9707686fb64205a680246a11324982d"
+source = "git+https://github.com/rjzak/hyper?branch=wasi_wip#7baf23da590823380ebae40efd77033fa601f514"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[patch.crates-io]
+hyper = { git = "https://github.com/rjzak/hyper", branch = "wasi_wip" }
+
 [package]
 name = "steward"
 version = "0.2.0"
@@ -28,8 +31,8 @@ tracing-subscriber = { version="^0.3.15", features = ["env-filter", "json"] }
 tower-http = { version = "^0.3.0", features = ["trace"] }
 axum = { version = "^0.5.16", features = ["headers"] }
 clap = { version = "^3.0.14", features = ["derive", "env"] }
-hyper = { version = "^0.14.17", features = ["full"] }
-tokio = { version = "^1.15.0", features = ["full"] }
+hyper = { git = "https://github.com/rjzak/hyper", branch = "wasi_wip", features = ["server"] }
+tokio = { version = "^1.21.2", features = ["rt", "macros"] }
 uuid = { version = "^0.8.2", features = ["v4"] }
 tracing = "^0.1.29"
 anyhow = "^1.0.55"
@@ -37,9 +40,12 @@ base64 = "^0.13.0"
 mime = "^0.3.16"
 confargs = "^0.1.3"
 
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+tokio = { version = "^1.21.2", features = ["rt-multi-thread", "macros"] }
+
 [dev-dependencies]
 tower = { version = "^0.4.11", features = ["util"] }
-axum = "^0.5.1"
+axum = "^0.5.16"
 http = "^0.2.6"
 memoffset = "0.6.4"
 rstest = "0.15"

--- a/Enarx.toml
+++ b/Enarx.toml
@@ -1,0 +1,14 @@
+[[files]]
+kind = "stdin"
+
+[[files]]
+kind = "stdout"
+
+[[files]]
+kind = "stderr"
+
+[[files]]
+kind = "listen"
+prot = "tcp"
+port = 8443
+name = "TEST_TCP_LISTEN"

--- a/Enarx.toml
+++ b/Enarx.toml
@@ -11,4 +11,4 @@ kind = "stderr"
 kind = "listen"
 prot = "tcp"
 port = 8443
-name = "TEST_TCP_LISTEN"
+name = "ingest"

--- a/deny.toml
+++ b/deny.toml
@@ -16,3 +16,6 @@ allow = [
     "BSD-3-Clause",
     "Unicode-DFS-2016",
 ]
+
+[sources.allow-org]
+github = ["rjzak"] # temporary until https://github.com/hyperium/hyper/pull/2900 is merged

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,8 @@
 
         nativeBin = buildPackage {};
         wasm32WasiBin = buildPackage {
+          nativeBuildInputs = [enarxBin];
+
           CARGO_BUILD_TARGET = "wasm32-wasi";
         };
         x86_64LinuxMuslBin = buildPackage {

--- a/flake.nix
+++ b/flake.nix
@@ -65,10 +65,9 @@
         buildPackage = extraArgs: craneLib.buildPackage (commonArgs // {inherit cargoArtifacts;} // extraArgs);
 
         nativeBin = buildPackage {};
-        # TODO: Add wasm32-wasi support
-        #wasm32WasiBin = buildPackage {
-        #  CARGO_BUILD_TARGET = "wasm32-wasi";
-        #};
+        wasm32WasiBin = buildPackage {
+          CARGO_BUILD_TARGET = "wasm32-wasi";
+        };
         x86_64LinuxMuslBin = buildPackage {
           CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
@@ -88,8 +87,7 @@
         formatter = pkgs.alejandra;
 
         packages."${cargo.toml.package.name}" = nativeBin;
-        # TODO: Add wasm32-wasi support
-        #packages."${cargo.toml.package.name}-wasm32-wasi" = wasm32WasiBin;
+        packages."${cargo.toml.package.name}-wasm32-wasi" = wasm32WasiBin;
         packages."${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
         packages."${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
         packages.default = nativeBin;

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
           nativeBuildInputs = [enarxBin];
 
           CARGO_BUILD_TARGET = "wasm32-wasi";
+          CARGO_TARGET_WASM_WASI32_RUNNER = "enarx run --wasmcfgfile ${self}/Enarx.toml";
         };
         x86_64LinuxMuslBin = buildPackage {
           CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
@@ -88,11 +89,18 @@
       in {
         formatter = pkgs.alejandra;
 
-        packages."${cargo.toml.package.name}" = nativeBin;
-        packages."${cargo.toml.package.name}-wasm32-wasi" = wasm32WasiBin;
-        packages."${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
-        packages."${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
-        packages.default = nativeBin;
+        packages =
+          {
+            default = nativeBin;
+
+            "${cargo.toml.package.name}" = nativeBin;
+            "${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
+            "${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
+          }
+          # TODO: Remove once an overlay is created in enarx
+          // (pkgs.lib.optionalAttrs (system != "powerpc64le-linux") {
+            "${cargo.toml.package.name}-wasm32-wasi" = wasm32WasiBin;
+          });
 
         devShells.default = pkgs.mkShell {
           buildInputs =

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,5 @@
 [toolchain]
 channel = "stable"
 components = [ "rustfmt", "clippy" ]
-targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]
 profile = "minimal"
-targets = [ "x86_64-unknown-linux-musl" ]
+targets = [ "wasm32-wasi", "x86_64-unknown-linux-musl" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
 channel = "stable"
 components = [ "rustfmt", "clippy" ]
+targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]
 profile = "minimal"
 targets = [ "x86_64-unknown-linux-musl" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,8 +204,8 @@ impl State {
     }
 }
 
+#[cfg_attr(not(target_os = "wasi"), tokio::main)]
 #[cfg_attr(target_os = "wasi", tokio::main(flavor = "current_thread"))]
-#[cfg_attr(any(target_family = "unix", windows), tokio::main)]
 async fn main() -> anyhow::Result<()> {
     if std::env::var("RUST_LOG_JSON").is_ok() {
         tracing_subscriber::fmt::fmt()


### PR DESCRIPTION
Uses RustCrypto, tests pass with both Wasmtime and Enarx!

Likely there will be requested changes to `.cargo/config` around the default target and preferred WebAssembly runtime.

Signed-off-by: Richard Zak <richard@profian.com>