### PR TITLE
ci: various improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-native:
     strategy:
       matrix:
         platform:
@@ -31,22 +31,39 @@ jobs:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-    - run: nix build -L ${{ matrix.platform.buildArgs }} '.#steward-${{ matrix.platform.target }}'
+    - run: nix build -L '.#steward-${{ matrix.platform.target }}'
     - run: nix run --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=ginstall -p ./result/bin/steward "steward-${{ matrix.platform.target }}"
     - uses: actions/upload-artifact@v3
       with:
         name: steward-${{ matrix.platform.target }}
         path: steward-${{ matrix.platform.target }}
 
-    - run: nix build -L ${{ matrix.platform.buildArgs }} '.#steward-${{ matrix.platform.target }}-oci'
+    - run: nix build -L '.#steward-${{ matrix.platform.target }}-oci'
     - run: nix run --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=ginstall -p ./result "steward-${{ matrix.platform.target }}-oci"
     - uses: actions/upload-artifact@v3
       with:
         name: steward-${{ matrix.platform.target }}-oci
         path: steward-${{ matrix.platform.target }}-oci
 
+  build-wasm:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v17
+    - uses: cachix/cachix-action@v10
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - run: nix build -L '.#steward-wasm32-wasi'
+    - run: nix run --inputs-from . 'nixpkgs#coreutils' -- --coreutils-prog=ginstall -p ./result/bin/steward.wasm steward-wasm32-wasi
+    - uses: actions/upload-artifact@v3
+      with:
+        name: steward-wasm32-wasi
+        path: steward-wasm32-wasi
+
   test-bin:
-    needs: build
+    needs: build-native
     strategy:
       matrix:
         platform:
@@ -61,7 +78,7 @@ jobs:
     - run: ./steward-${{ matrix.platform.target }} --help
 
   test-oci:
-    needs: build
+    needs: build-native
     strategy:
       matrix:
         platform:
@@ -79,9 +96,13 @@ jobs:
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
-    needs: [ build, test-bin, test-oci ]
+    needs: [ build-native, build-wasm, test-bin, test-oci ]
     runs-on: ubuntu-20.04
     steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: steward-wasm32-wasi
+
     - uses: actions/download-artifact@v3
       with:
         name: steward-x86_64-unknown-linux-musl
@@ -94,5 +115,6 @@ jobs:
         draft: true
         prerelease: true
         files: |
+          steward-wasm32-wasi
           steward-x86_64-unknown-linux-musl
           steward-x86_64-unknown-linux-musl-oci

--- a/flake.nix
+++ b/flake.nix
@@ -23,106 +23,107 @@
     rust-overlay,
     ...
   }:
-    flake-utils.lib.eachSystem [
-      "aarch64-darwin"
-      "aarch64-linux"
-      "powerpc64le-linux"
-      "x86_64-darwin"
-      "x86_64-linux"
-    ] (
-      system: let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [(import rust-overlay)];
-        };
-
-        # TODO: Add and use an overlay
-        enarxBin = enarx.packages.${system}.default;
-
-        rust = pkgs.rust-bin.fromRustupToolchainFile "${self}/rust-toolchain.toml";
-
-        cargo.toml = builtins.fromTOML (builtins.readFile "${self}/Cargo.toml");
-        src =
-          pkgs.nix-gitignore.gitignoreRecursiveSource [
-            "*.nix"
-            "*.yml"
-            "/.github"
-            "flake.lock"
-            "LICENSE"
-            "rust-toolchain.toml"
-          ]
-          self;
-
-        craneLib = (crane.mkLib pkgs).overrideToolchain rust;
-
-        commonArgs = {
-          pname = cargo.toml.package.name;
-          inherit (cargo.toml.package) version;
-          inherit src;
-        };
-
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-        commonArtifactArgs = commonArgs // {inherit cargoArtifacts;};
-
-        cargoClippy = craneLib.cargoClippy (commonArtifactArgs // {cargoClippyExtraArgs = "--all-targets --workspace -- --deny warnings";});
-        cargoFmt = craneLib.cargoFmt commonArtifactArgs;
-        cargoNextest = craneLib.cargoNextest commonArtifactArgs;
-
-        buildPackage = extraArgs: craneLib.buildPackage (commonArtifactArgs // extraArgs);
-        nativeBin = buildPackage {};
-        wasm32WasiBin = buildPackage {
-          nativeBuildInputs = [enarxBin];
-
-          CARGO_BUILD_TARGET = "wasm32-wasi";
-          CARGO_TARGET_WASM_WASI32_RUNNER = "enarx run --wasmcfgfile ${self}/Enarx.toml";
-        };
-        x86_64LinuxMuslBin = buildPackage {
-          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
-          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-        };
-
-        buildImage = bin:
-          pkgs.dockerTools.buildImage {
-            inherit (cargo.toml.package) name;
-            tag = cargo.toml.package.version;
-            contents = [
-              bin
-            ];
-            config.Cmd = [cargo.toml.package.name];
-            config.Env = ["PATH=${bin}/bin"];
+    with flake-utils.lib.system;
+      flake-utils.lib.eachSystem [
+        aarch64-darwin
+        aarch64-linux
+        powerpc64le-linux
+        x86_64-darwin
+        x86_64-linux
+      ] (
+        system: let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [(import rust-overlay)];
           };
-      in {
-        formatter = pkgs.alejandra;
 
-        checks.clippy = cargoClippy;
-        checks.fmt = cargoFmt;
-        checks.nextest = cargoNextest;
+          # TODO: Add and use an overlay
+          enarxBin = enarx.packages.${system}.default;
 
-        packages =
-          {
-            default = nativeBin;
+          rust = pkgs.rust-bin.fromRustupToolchainFile "${self}/rust-toolchain.toml";
 
-            "${cargo.toml.package.name}" = nativeBin;
-            "${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
-            "${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
-          }
-          # TODO: Remove once an overlay is created in enarx
-          // (pkgs.lib.optionalAttrs (system != "powerpc64le-linux") {
-            "${cargo.toml.package.name}-wasm32-wasi" = wasm32WasiBin;
-          });
-
-        devShells.default = pkgs.mkShell {
-          buildInputs =
-            [
-              pkgs.openssl
-              pkgs.wasmtime
-
-              rust
+          cargo.toml = builtins.fromTOML (builtins.readFile "${self}/Cargo.toml");
+          src =
+            pkgs.nix-gitignore.gitignoreRecursiveSource [
+              "*.nix"
+              "*.yml"
+              "/.github"
+              "flake.lock"
+              "LICENSE"
+              "rust-toolchain.toml"
             ]
-            # TODO: Add Enarx, once an overlay is created in enarx
-            ++ (pkgs.lib.optional (system != "powerpc64le-linux") enarxBin);
-        };
-      }
-    );
+            self;
+
+          craneLib = (crane.mkLib pkgs).overrideToolchain rust;
+
+          commonArgs = {
+            pname = cargo.toml.package.name;
+            inherit (cargo.toml.package) version;
+            inherit src;
+          };
+
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          commonArtifactArgs = commonArgs // {inherit cargoArtifacts;};
+
+          cargoClippy = craneLib.cargoClippy (commonArtifactArgs // {cargoClippyExtraArgs = "--all-targets --workspace -- --deny warnings";});
+          cargoFmt = craneLib.cargoFmt commonArtifactArgs;
+          cargoNextest = craneLib.cargoNextest commonArtifactArgs;
+
+          buildPackage = extraArgs: craneLib.buildPackage (commonArtifactArgs // extraArgs);
+          nativeBin = buildPackage {};
+          wasm32WasiBin = buildPackage {
+            nativeBuildInputs = [enarxBin];
+
+            CARGO_BUILD_TARGET = "wasm32-wasi";
+            CARGO_TARGET_WASM_WASI32_RUNNER = "enarx run --wasmcfgfile ${self}/Enarx.toml";
+          };
+          x86_64LinuxMuslBin = buildPackage {
+            CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+          };
+
+          buildImage = bin:
+            pkgs.dockerTools.buildImage {
+              inherit (cargo.toml.package) name;
+              tag = cargo.toml.package.version;
+              contents = [
+                bin
+              ];
+              config.Cmd = [cargo.toml.package.name];
+              config.Env = ["PATH=${bin}/bin"];
+            };
+        in {
+          formatter = pkgs.alejandra;
+
+          checks.clippy = cargoClippy;
+          checks.fmt = cargoFmt;
+          checks.nextest = cargoNextest;
+
+          packages =
+            {
+              default = nativeBin;
+
+              "${cargo.toml.package.name}" = nativeBin;
+              "${cargo.toml.package.name}-x86_64-unknown-linux-musl" = x86_64LinuxMuslBin;
+              "${cargo.toml.package.name}-x86_64-unknown-linux-musl-oci" = buildImage x86_64LinuxMuslBin;
+            }
+            # TODO: Remove once an overlay is created in enarx
+            // (pkgs.lib.optionalAttrs (system != powerpc64le-linux) {
+              "${cargo.toml.package.name}-wasm32-wasi" = wasm32WasiBin;
+            });
+
+          devShells.default = pkgs.mkShell {
+            buildInputs =
+              [
+                pkgs.openssl
+                pkgs.wasmtime
+
+                rust
+              ]
+              # TODO: Add Enarx, once an overlay is created in enarx
+              ++ (pkgs.lib.optional (system != powerpc64le-linux) enarxBin);
+          };
+        }
+      );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -62,8 +62,14 @@
         };
 
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        buildPackage = extraArgs: craneLib.buildPackage (commonArgs // {inherit cargoArtifacts;} // extraArgs);
 
+        commonArtifactArgs = commonArgs // {inherit cargoArtifacts;};
+
+        cargoClippy = craneLib.cargoClippy (commonArtifactArgs // {cargoClippyExtraArgs = "--all-targets --workspace -- --deny warnings";});
+        cargoFmt = craneLib.cargoFmt commonArtifactArgs;
+        cargoNextest = craneLib.cargoNextest commonArtifactArgs;
+
+        buildPackage = extraArgs: craneLib.buildPackage (commonArtifactArgs // extraArgs);
         nativeBin = buildPackage {};
         wasm32WasiBin = buildPackage {
           nativeBuildInputs = [enarxBin];
@@ -88,6 +94,10 @@
           };
       in {
         formatter = pkgs.alejandra;
+
+        checks.clippy = cargoClippy;
+        checks.fmt = cargoFmt;
+        checks.nextest = cargoNextest;
 
         packages =
           {

--- a/src/main.rs
+++ b/src/main.rs
@@ -539,7 +539,7 @@ mod tests {
 
             let path = if multi {
                 let response = Output::from_der(body.as_ref()).unwrap();
-                let mut path = PkiPath::from(response.chain);
+                let mut path = response.chain;
                 path.push(response.issued[0].clone());
                 path
             } else {
@@ -633,12 +633,13 @@ mod tests {
             let crs = Vec::<CertReq<'_>>::from_der(&one_cr_bytes).unwrap();
             assert_eq!(crs.len(), 1);
 
-            let mut five_crs = Vec::new();
-            five_crs.push(crs[0].clone());
-            five_crs.push(crs[0].clone());
-            five_crs.push(crs[0].clone());
-            five_crs.push(crs[0].clone());
-            five_crs.push(crs[0].clone());
+            let five_crs = vec![
+                crs[0].clone(),
+                crs[0].clone(),
+                crs[0].clone(),
+                crs[0].clone(),
+                crs[0].clone(),
+            ];
 
             let request = Request::builder()
                 .method("POST")


### PR DESCRIPTION
With this PR in place, CI now builds wasm32-wasi and tests it against enarx via `nix`
`nix flake check` now also runs `cargo fmt`, `cargo clippy` and `cargo nextest` (and fails if either fails)