### PR TITLE
ci: add `test` release job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
     - uses: cachix/cachix-action@v11
       with:
         name: enarx
@@ -36,6 +39,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
     - uses: cachix/cachix-action@v11
       with:
         name: enarx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,19 @@ jobs:
         path: steward-${{ matrix.platform.target }}-oci
     - run: ${{ matrix.platform.test-oci }}
 
+  test:
+    needs: build
+    strategy:
+      matrix:
+        host: [ ubuntu-latest ]
+    runs-on: ${{ matrix.host }}
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: steward-x86_64-unknown-linux-musl
+    - run: chmod +x ./steward-x86_64-unknown-linux-musl
+    - run: ./steward-x86_64-unknown-linux-musl --help
+
   release:
     needs: build
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
     - uses: cachix/cachix-action@v11
       with:
         name: enarx


### PR DESCRIPTION
- Prevent actions using `nix` from getting rate-limited by setting a token
- Add `test` job, which tests portability of binaries and is used as a "marker" for successful build