### PR TITLE
refactor: use `wasmtime` for `cargo test`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,3 @@
 [target.wasm32-wasi]
 rustflags = ["--cfg", "tokio_unstable"]
-runner = ["enarx", "run", "--wasmcfgfile", "Enarx.toml"]
+runner = ["wasmtime"]


### PR DESCRIPTION
The `Enarx.toml` is not required for tests to run, just use `wasmtime` directly for speed and simplicity