### PR TITLE
fix: small corrections

### DIFF
--- a/crates/sgx_validation/src/lib.rs
+++ b/crates/sgx_validation/src/lib.rs
@@ -89,53 +89,53 @@ impl Sgx {
                 hash.as_slice() == &rpt.reportdata[..hash.as_slice().len()],
                 "sgx report data is invalid"
             );
+        }
 
-            if let Some(config) = config {
-                if !config.measurements.signer.is_empty() {
-                    let signed = config.measurements.signer.contains(&rpt.mrsigner);
-                    ensure!(signed, "sgx untrusted enarx signer");
-                }
+        if let Some(config) = config {
+            if !config.measurements.signer.is_empty() {
+                let signed = config.measurements.signer.contains(&rpt.mrsigner);
+                ensure!(signed, "sgx untrusted enarx signer");
+            }
 
-                if !config.measurements.hash.is_empty() {
-                    let approved = config.measurements.hash.contains(&rpt.mrenclave);
-                    ensure!(approved, "sgx untrusted enarx hash");
-                }
+            if !config.measurements.hash.is_empty() {
+                let approved = config.measurements.hash.contains(&rpt.mrenclave);
+                ensure!(approved, "sgx untrusted enarx hash");
+            }
 
-                if !config.measurements.hash_blacklist.is_empty() {
-                    let denied = config.measurements.hash_blacklist.contains(&rpt.mrenclave);
-                    ensure!(!denied, "sgx untrusted enarx hash");
-                }
+            if !config.measurements.hash_blacklist.is_empty() {
+                let denied = config.measurements.hash_blacklist.contains(&rpt.mrenclave);
+                ensure!(!denied, "sgx untrusted enarx hash");
+            }
 
-                if let Some(product_id) = config.enclave_product_id {
-                    ensure!(
-                        rpt.enclave_product_id() == product_id,
-                        "sgx untrusted enclave product id",
-                    );
-                }
+            if let Some(product_id) = config.enclave_product_id {
+                ensure!(
+                    rpt.enclave_product_id() == product_id,
+                    "sgx untrusted enclave product id",
+                );
+            }
 
-                if let Some(version) = config.enclave_security_version {
-                    ensure!(
-                        rpt.enclave_security_version() >= version,
-                        "sgx untrusted enclave security version"
-                    );
-                }
+            if let Some(version) = config.enclave_security_version {
+                ensure!(
+                    rpt.enclave_security_version() >= version,
+                    "sgx untrusted enclave security version"
+                );
+            }
 
-                if !config.features.is_empty()
-                    && !rpt
-                        .attributes()
-                        .features()
-                        .difference(config.features)
-                        .is_empty()
-                {
-                    bail!("sgx untrusted features");
-                }
+            if !config.features.is_empty()
+                && !rpt
+                    .attributes()
+                    .features()
+                    .difference(config.features)
+                    .is_empty()
+            {
+                bail!("sgx untrusted features");
+            }
 
-                if !config.misc_select.is_empty() {
-                    ensure!(
-                        rpt.misc_select().difference(config.misc_select).is_empty(),
-                        "sgx untrusted misc select"
-                    );
-                }
+            if !config.misc_select.is_empty() {
+                ensure!(
+                    rpt.misc_select().difference(config.misc_select).is_empty(),
+                    "sgx untrusted misc select"
+                );
             }
         }
 

--- a/crates/snp_validation/src/lib.rs
+++ b/crates/snp_validation/src/lib.rs
@@ -306,8 +306,6 @@ impl Snp {
         )
         .context("snp report contains invalid signature")?;
 
-        // TODO: additional field validations.
-
         // Should only be version 2
         ensure!(
             report.body.version == 2,
@@ -369,14 +367,14 @@ impl Snp {
             "snp report platform_info reserved fields were set"
         );
 
+        // Check fields not set by Enarx
         ensure!(report.body.sig_algo == 1, "snp signature algorithm not 1");
 
-        // Check fields not set by Enarx
+        // Check fields set by Enarx
         ensure!(report.body.family_id == [0; 16], "snp family id was set");
 
         ensure!(report.body.image_id == [0; 16], "snp image id was set");
 
-        // Check fields set by Enarx
         ensure!(
             report.body.host_data == [0; 32],
             "snp report host_data field should not be set by Enarx"


### PR DESCRIPTION
If it was not used in tests the `dbg` flag could be removed from the `snp` and `sgx` `verify()` method.