### PR TITLE
feat: check CRLs during attestation

### DIFF
--- a/crates/attestation/src/sgx/mod.rs
+++ b/crates/attestation/src/sgx/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#![allow(unused_variables, unused_imports)] // temporary until CRL validation enabled
-
 pub mod config;
 pub mod quote;
 
@@ -17,6 +15,7 @@ use const_oid::ObjectIdentifier;
 use der::{Decode, Encode};
 use sgx::pck::SgxExtension;
 use sha2::{Digest, Sha256};
+#[cfg(debug_assertions)]
 use tracing::debug;
 use x509::{ext::Extension, request::CertReqInfo, Certificate, PkiPath, TbsCertificate};
 
@@ -44,7 +43,7 @@ impl Sgx {
             signer = signer.verify_crt(cert)?;
         }
 
-        //PkiPath::from(chain).check_crl(crls)?;
+        PkiPath::from(chain).check_crl(crls)?;
 
         Ok(signer)
     }
@@ -96,7 +95,7 @@ impl Sgx {
         // Parse the TCB certificate chain
         let tcb_chain = &quote.tcb.certs;
         ensure!(chain[0] == tcb_chain[0], "sgx TCB root not SGX root");
-        let tcb_signer = self.trusted(tcb_chain, &quote.crls)?;
+        self.trusted(tcb_chain, &quote.crls)?;
 
         // Validate TCB report
         tcb_chain[1]

--- a/crates/attestation/src/sgx/quote/mod.rs
+++ b/crates/attestation/src/sgx/quote/mod.rs
@@ -24,7 +24,6 @@ use traits::{FromBytes, ParseBytes, Steal};
 use anyhow::anyhow;
 use der::{Decode, Encode, Sequence};
 use p256::ecdsa::signature::Verifier;
-use rustls_pemfile::ec_private_keys;
 use sgx::ReportBody;
 use sha2::{digest::DynDigest, Sha256};
 use tcb::{TcbInfo, TcbRoot};

--- a/crates/attestation/src/sgx/quote/tcb.rs
+++ b/crates/attestation/src/sgx/quote/tcb.rs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use std::cmp::Ordering;
-use std::time::SystemTime;
-
 use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 

--- a/crates/attestation/src/snp/mod.rs
+++ b/crates/attestation/src/snp/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#![allow(unused_variables, unused_imports)] // temporary until CRL validation enabled
-
 pub mod config;
 
 use self::config::Config;
@@ -254,9 +252,9 @@ impl Snp {
 
             if let Some(signer) = signer {
                 if signer == &vcek.tbs_certificate {
-                    //let mut path = path;
-                    //path.push(vcek.clone());
-                    //path.check_crl(&certs.crl)?;
+                    let mut path = path;
+                    path.push(vcek.clone());
+                    path.check_crl(&certs.crl)?;
                     return Ok(&vcek.tbs_certificate);
                 }
             }


### PR DESCRIPTION
Follow-up to https://github.com/profianinc/steward/pull/159
Closes: https://github.com/profianinc/steward/issues/112

* Make sure CRL checking works for both Intel (works via CRL-by-Issuer) & AMD.
* Identify CRL from the pair only by URL.
* Handle both cases:
  * CRL per CA cert
  * CRL from root CA cert only
* Logger message for expired CRL